### PR TITLE
Create employee page with client assignment feature

### DIFF
--- a/backend/fetch/fetchEmployees.ts
+++ b/backend/fetch/fetchEmployees.ts
@@ -27,7 +27,7 @@ async function checkIfEmployeeIdExists(id: number) {
 }
 
 async function createEmployee(id: number, email: string, name: string | null, surname: string | null,
-    birthdate: string | null, gender: string | null, work: string | null, image: string | null, role: string | null, constumerIdsList: number[]) {
+    birthdate: string | null, gender: string | null, work: string | null, image: string | null, customerIdsList: number[]) {
     await prisma.employee.create({
         data: {
             id: id,
@@ -39,8 +39,8 @@ async function createEmployee(id: number, email: string, name: string | null, su
             work: work,
             image: image,
             // @ts-ignore
-            role: (work === "coach") ? Role.COACH : Role.MANAGER,
-            constumerIds: constumerIdsList
+            role: (work === "Coach") ? "COACH" : "MANAGER",
+            customerIds: customerIdsList
         }
     });
 }
@@ -72,6 +72,8 @@ async function fetchEmployeeDetails(token: string, employeeId: number) {
 
         if (response.statusCode !== 200) {
             console.log("Error: Could not fetch data for employee id: ", employeeId);
+            console.log("Status code: ", response.statusCode);
+            console.log("Body: ", response.body);
             return null;
         }
         return JSON.parse(response.body);
@@ -93,10 +95,13 @@ async function fetchEmployeeImage(token: string, employeeId: number): Promise<st
         });
         if (!response.ok) {
             console.log("Error: Could not fetch image for employee id: ", employeeId);
+            console.log("Status code: ", response.status);
+            console.log("Body: ", response.body);
             return null;
         }
-        const imageBuffer = await response.buffer();
-        return imageBuffer.toString('base64');
+        const employeeImage = await response.buffer();
+        const employeeImageStr = employeeImage.toString('base64');
+        return employeeImageStr;
     } catch (error) {
         console.log("Error: ", error);
         return null;
@@ -106,14 +111,14 @@ async function fetchEmployeeImage(token: string, employeeId: number): Promise<st
 async function getEmployeeDetails(token: string, employeeId: number) {
     const employee = await fetchEmployeeDetails(token, employeeId);
     const employeeImage = await fetchEmployeeImage(token, employeeId);
-    const constumerIdsList: number[] = [];
+    const customerIdsList: number[] = [];
 
     if (employee === null) return;
     if (await checkIfEmployeeIdExists(employeeId)) {
         await updateEmployeeImageIfNull(employeeId, employeeImage);
     } else {
-        await createEmployee(employee.id, employee.email, employee.name, employee.surname, employee.birthdate,
-            employee.gender, employee.work, employeeImage, employee.role, constumerIdsList);
+        await createEmployee(employee.id, employee.email, employee.name, employee.surname, employee.birth_date,
+            employee.gender, employee.work, employeeImage, customerIdsList);
     }
 }
 
@@ -134,6 +139,8 @@ module.exports = async function fetchEmployees(token: string) {
 
         if (response.statusCode !== 200) {
             console.log("Error: Could not fetch data from employees");
+            console.log("Status code: ", response.statusCode);
+            console.log("Body: ", response.body);
             return;
         }
         const employees = JSON.parse(response.body);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "core-js": "^3.8.3",
     "primeflex": "^3.3.1",
     "primeicons": "^7.0.0",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,6 +7,10 @@ import Menubar from 'primevue/menubar';
 import Ripple from "primevue/ripple";
 import StyleClass from 'primevue/styleclass';
 import Image from 'primevue/image';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import Dialog from 'primevue/dialog';
+import Checkbox from 'primevue/checkbox';
 
 // Import css
 import './assets/main.css'
@@ -31,5 +35,9 @@ app.component('AppSidebar', AppSidebar);
 app.component('PrimeMenubar', Menubar);
 app.component('PrimeButton', Button);
 app.component('InputText', InputText);
+app.component('PrimeDataTable', DataTable);
+app.component('PrimeColumn', Column);
+app.component('PrimeDialog', Dialog);
+app.component('PrimeCheckbox', Checkbox);
 
 app.mount('#app')

--- a/frontend/src/pages/AppEmployees.vue
+++ b/frontend/src/pages/AppEmployees.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+    import axios from 'axios';
+    import { ref, onMounted } from 'vue';
+
+    var employeesData = ref([]);
+    const clients = ref([]);
+
+    onMounted(async () => {
+        const response = await axios.get('http://localhost:3000/employee');
+        employeesData.value = response.data.sort((a, b) => a.id - b.id);
+        employeesData.value.forEach(employee => {
+                employee.lastLogin = new Date(employee.lastLogin).toLocaleDateString();
+        });
+        const clientsResponse = await axios.get('http://localhost:3000/customers');
+        clients.value = clientsResponse.data;
+    });
+    var visible = ref(false);
+    
+    var selectedClients = ref([]);
+    var oldSelectedClients = ref([]);
+    var currentEmployeeId = ref(0);
+
+    const enterEdit = async (id : number) => {
+        const customersListResponse = await axios.get('http://localhost:3000/employee/' + id + '/customerslist');
+        selectedClients.value = customersListResponse.data.map(client => client.id);
+        oldSelectedClients.value = customersListResponse.data.map(client => client.id);
+        visible.value = true;
+        currentEmployeeId.value = id;
+    };
+
+    const cancelEdit = () => {
+        selectedClients.value = [];
+        oldSelectedClients.value = [];
+        currentEmployeeId.value = 0;
+        visible.value = false;
+    };
+
+    const updateEdit = async () => {
+        const id = currentEmployeeId.value;
+        for (let selectedClient of selectedClients.value) {
+            if (!oldSelectedClients.value.includes(selectedClient)) {
+                console.log('Client Added id ' + selectedClient);
+                await axios.put('http://localhost:3000/employee/' + id + '/customerslist/add/' + selectedClient);
+            }
+        }
+        for (let oldSelectedClient of oldSelectedClients.value) {
+            if (!selectedClients.value.includes(oldSelectedClient)) {
+                console.log('Client Removed id ' + oldSelectedClient);
+                await axios.put('http://localhost:3000/employee/' + id + '/customerslist/remove/' + oldSelectedClient);
+            }
+        }
+        selectedClients.value = [];
+        oldSelectedClients.value = [];
+        currentEmployeeId.value = 0;
+        visible.value = false;
+    };
+</script>
+
+<template>
+  <div>
+    <h1>Coaches</h1>
+    <hr />
+    <div class="p-7">
+        <PrimeDataTable :value="employeesData" showGridlines scrollable scrollHeight="700px">
+            <PrimeColumn field="id" sortable header="#"></PrimeColumn>
+            <PrimeColumn field="name" sortable header="Name"></PrimeColumn>
+            <PrimeColumn field="surname" sortable header="Surname"></PrimeColumn>
+            <PrimeColumn field="birthdate" sortable header="Birth Date"></PrimeColumn>
+            <PrimeColumn>
+                <template #header>
+                    <div>Customers</div>
+                </template>
+                <template #body="slotProps">
+                    <div v-if="slotProps.data.work !== 'Coach'">
+                        <span class="p-text-secondary">This employee is not a coach</span>
+                    </div>
+
+                    <div v-else>
+                        <PrimeButton icon="pi pi-pen-to-square" label="Edit coach customers" severity="info" rounded aria-label="User" @click="enterEdit(slotProps.data.id)"></PrimeButton>
+
+                        <PrimeDialog v-model:visible="visible" modal header="Edit coach customers" :style="{ width: '50rem' }" :breakpoints="{ '1199px': '75vw', '575px': '90vw' }">
+                            <span class="p-text-secondary block mb-5">Select the customers that you want to assign to this coach</span>
+
+                            <div class="flex flex-column gap-4 px-4 pb-4">
+                                <div v-for="client of clients" :key="client.id" class="flex items-center gap-2">
+                                    <PrimeCheckbox v-model="selectedClients" name="client" :value="client.id"></PrimeCheckbox>
+                                    <label :for="client.id">{{ client.name }} {{ client.surname }}</label>
+                                </div>
+                            </div>
+
+                            <div class="flex justify-content-end gap-2">
+                                <PrimeButton type="button" label="Cancel" severity="secondary" @click="cancelEdit()"></PrimeButton>
+                                <PrimeButton type="button" label="Save" @click="updateEdit()"></PrimeButton>
+                            </div>
+                        </PrimeDialog>
+                    </div>
+
+                </template>
+            </PrimeColumn>
+            <PrimeColumn field="lastLogin" sortable header="Last connection"></PrimeColumn>
+        </PrimeDataTable>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -6,6 +6,7 @@ import login from "@/pages/master/AppLogin.vue";
 import profile from "@/pages/AppProfile.vue";
 import astrological from "@/pages/AppAstrological.vue";
 import wardrobe from "@/pages/AppWardrobe.vue";
+import employees from "@/pages/AppEmployees.vue";
 
 
 const routes = [
@@ -38,6 +39,11 @@ const routes = [
         name: 'Wardrobe',
         path: '/wardrobe',
         component: wardrobe
+    },
+    {
+        name: 'Employees',
+        path: '/employees',
+        component: employees
     }
 ];
 


### PR DESCRIPTION
This PR adds a new employee page where all employees (e.g., coaches) are listed. Admins can now view the entire list of employees and assign clients directly to coaches. The page includes:
- A table or list displaying all employees.
- A feature to select an employee and assign one or more clients to them.

This new page improves the management of employee-client relationships by centralizing the assignment process.